### PR TITLE
Add dataset_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ You can use the `--release_version` flag to specify the dataset version you wish
 python -m lcb_runner.runner.main --model {model_name} --scenario codegeneration --evaluate --release_version release_v2
 ```
 
+You can also load a dataset from a custom location using the `--dataset_path` flag which accepts a local directory or Hugging Face dataset identifier.
+For example,
+
+```bash
+python -m lcb_runner.runner.main --model {model_name} --scenario codegeneration --dataset_path path/to/custom_dataset
+```
+
 ### Code Generation
 
 We use `vllm` for inference using open models. By default, we use  `tensor_parallel_size=${num_gpus}` to parallelize inference across all available GPUs. It can be configured using the  `--tensor_parallel_size` flag as required. 

--- a/lcb_runner/benchmarks/code_execution.py
+++ b/lcb_runner/benchmarks/code_execution.py
@@ -56,8 +56,15 @@ class CodeExecutionProblem:
         }
 
 
-def load_code_execution_dataset(release_version="release_v1") -> list[CodeExecutionProblem]:
-    dataset = load_dataset("livecodebench/execution-v2", split="test")
+def load_code_execution_dataset(
+    release_version="release_v1",
+    dataset_path=None,
+) -> list[CodeExecutionProblem]:
+    if dataset_path is None:
+        dataset_name = "livecodebench/execution-v2"
+    else:
+        dataset_name = dataset_path
+    dataset = load_dataset(dataset_name, split="test")
     dataset = [CodeExecutionProblem(**p) for p in dataset]  # type: ignore
     print(f"Loaded {len(dataset)} problems")
     return dataset

--- a/lcb_runner/benchmarks/code_generation.py
+++ b/lcb_runner/benchmarks/code_generation.py
@@ -121,8 +121,22 @@ class CodeGenerationProblem:
         }
 
 
-def load_code_generation_dataset(release_version="release_v1", start_date=None, end_date=None) -> list[CodeGenerationProblem]:
-    dataset = load_dataset("livecodebench/code_generation_lite", split="test", version_tag=release_version, trust_remote_code=True)
+def load_code_generation_dataset(
+    release_version="release_v1",
+    start_date=None,
+    end_date=None,
+    dataset_path=None,
+) -> list[CodeGenerationProblem]:
+    if dataset_path is None:
+        dataset_name = "livecodebench/code_generation_lite"
+    else:
+        dataset_name = dataset_path
+    dataset = load_dataset(
+        dataset_name,
+        split="test",
+        version_tag=release_version,
+        trust_remote_code=True,
+    )
     dataset = [CodeGenerationProblem(**p) for p in dataset]  # type: ignore
     if start_date is not None:
         p_start_date = datetime.strptime(start_date, "%Y-%m-%d")
@@ -136,8 +150,15 @@ def load_code_generation_dataset(release_version="release_v1", start_date=None, 
     return dataset
 
 
-def load_code_generation_dataset_not_fast(release_version="release_v1") -> list[CodeGenerationProblem]:
-    dataset = load_dataset("livecodebench/code_generation", split="test")
+def load_code_generation_dataset_not_fast(
+    release_version="release_v1",
+    dataset_path=None,
+) -> list[CodeGenerationProblem]:
+    if dataset_path is None:
+        dataset_name = "livecodebench/code_generation"
+    else:
+        dataset_name = dataset_path
+    dataset = load_dataset(dataset_name, split="test")
     dataset = [CodeGenerationProblem(**p) for p in dataset]  # type: ignore
     print(f"Loaded {len(dataset)} problems")
     return dataset

--- a/lcb_runner/benchmarks/test_output_prediction.py
+++ b/lcb_runner/benchmarks/test_output_prediction.py
@@ -59,8 +59,15 @@ class TestOutputPredictionProblem:
         }
 
 
-def load_test_prediction_dataset(release_version="release_v1") -> list[TestOutputPredictionProblem]:
-    dataset = load_dataset("livecodebench/test_generation", split="test")  # type: ignore
+def load_test_prediction_dataset(
+    release_version="release_v1",
+    dataset_path=None,
+) -> list[TestOutputPredictionProblem]:
+    if dataset_path is None:
+        dataset_name = "livecodebench/test_generation"
+    else:
+        dataset_name = dataset_path
+    dataset = load_dataset(dataset_name, split="test")  # type: ignore
     dataset = [TestOutputPredictionProblem(**d) for d in dataset]
     print(f"Loaded {len(dataset)} prediction problems")
     return dataset

--- a/lcb_runner/runner/parser.py
+++ b/lcb_runner/runner/parser.py
@@ -47,6 +47,12 @@ def get_args():
         help="whether to use CoT in code execution scenario",
     )
     parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default=None,
+        help="Optional local dataset directory or Hugging Face identifier",
+    )
+    parser.add_argument(
         "--n", type=int, default=10, help="Number of samples to generate"
     )
     parser.add_argument(

--- a/lcb_runner/runner/scenario_router.py
+++ b/lcb_runner/runner/scenario_router.py
@@ -50,26 +50,39 @@ def build_prompt_benchmark(
     if scenario == Scenario.codegeneration:
         not_fast: bool = args.not_fast
         if not_fast:
-            benchmark = load_code_generation_dataset_not_fast(args.release_version)
+            benchmark = load_code_generation_dataset_not_fast(
+                args.release_version,
+                dataset_path=args.dataset_path,
+            )
         else:
             benchmark = load_code_generation_dataset(
                 args.release_version,
                 start_date=args.start_date,
-                end_date=args.end_date
+                end_date=args.end_date,
+                dataset_path=args.dataset_path,
             )
         benchmark = sorted(benchmark, key=lambda x: x.question_id)
         format_prompt = format_prompt_generation
     elif scenario == Scenario.testoutputprediction:
-        benchmark = load_test_prediction_dataset(args.release_version)
+        benchmark = load_test_prediction_dataset(
+            args.release_version,
+            dataset_path=args.dataset_path,
+        )
         benchmark = sorted(benchmark, key=lambda x: (x.question_id, x.test_id))
         format_prompt = format_prompt_test_output
     elif scenario == Scenario.selfrepair:
-        benchmark = load_code_generation_dataset(args.release_version)
+        benchmark = load_code_generation_dataset(
+            args.release_version,
+            dataset_path=args.dataset_path,
+        )
         benchmark = sorted(benchmark, key=lambda x: x.question_id)
         format_prompt = format_prompt_self_repair
     elif scenario == Scenario.codeexecution:
         cot_code_execution: bool = args.cot_code_execution
-        benchmark = load_code_execution_dataset(args.release_version)
+        benchmark = load_code_execution_dataset(
+            args.release_version,
+            dataset_path=args.dataset_path,
+        )
         benchmark = sorted(benchmark, key=lambda x: int(x.id.split("_")[1]))
         if cot_code_execution:
             format_prompt = format_prompt_execution_cot


### PR DESCRIPTION
## Summary
- allow specifying an optional dataset path via `--dataset_path`
- thread dataset path through benchmark loaders and scenario router
- document dataset path usage in README

## Testing
- `python -m py_compile lcb_runner/runner/parser.py lcb_runner/benchmarks/code_generation.py lcb_runner/benchmarks/test_output_prediction.py lcb_runner/benchmarks/code_execution.py lcb_runner/runner/scenario_router.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8900d288832790d373d801217f30