### PR TITLE
Add Mistral-7B Instruct support

### DIFF
--- a/lcb_runner/lm_styles.py
+++ b/lcb_runner/lm_styles.py
@@ -654,7 +654,7 @@ LanguageModelList: list[LanguageModel] = [
         "Mistral-7B-Instruct-v0.2",
         LMStyle.MistralInstruct,
         datetime(2024, 9, 27),
-        link="https://mistral.ai/news/codestral/",
+        link="https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2",
     ),
     ## QwQ
     LanguageModel(

--- a/lcb_runner/prompts/code_execution.py
+++ b/lcb_runner/prompts/code_execution.py
@@ -153,6 +153,26 @@ def format_prompt_execution_base(
             {"role": "user", "content": prompt},
         ]
         return chat_messages
+    elif LanguageModelStyle == LMStyle.MistralInstruct:
+        chat_messages = [
+            {
+                "role": "system",
+                "content": system_message,
+            },
+            {"role": "user", "content": prompt},
+        ]
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            "mistralai/Mistral-7B-Instruct-v0.2", padding_side="left", use_fast=False
+        )
+        return tokenizer.apply_chat_template(
+            chat_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            truncation=False,
+            padding=False,
+        )
     elif LanguageModelStyle == LMStyle.DracarysLlama:
         chat_messages = [
             {

--- a/lcb_runner/prompts/code_generation.py
+++ b/lcb_runner/prompts/code_generation.py
@@ -315,6 +315,30 @@ def format_prompt_generation(
         ]
         return chat_messages
 
+    if LanguageModelStyle == LMStyle.MistralInstruct:
+        chat_messages = [
+            {
+                "role": "system",
+                "content": PromptConstants.SYSTEM_MESSAGE_GENERIC,
+            },
+            {
+                "role": "user",
+                "content": get_generic_question_template_answer(question),
+            },
+        ]
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            "mistralai/Mistral-7B-Instruct-v0.2", padding_side="left", use_fast=False
+        )
+        return tokenizer.apply_chat_template(
+            chat_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            truncation=False,
+            padding=False,
+        )
+
     if LanguageModelStyle == LMStyle.DeepSeekCodeInstruct:
         prompt = f"{PromptConstants.SYSTEM_MESSAGE_DEEPSEEK}\n\n"
         prompt += f"{get_deepseekcode_question_template_answer(question)}"

--- a/lcb_runner/prompts/self_repair.py
+++ b/lcb_runner/prompts/self_repair.py
@@ -246,6 +246,28 @@ def format_prompt_self_repair(
             },
         ]
         return chat_messages
+    elif LanguageModelStyle == LMStyle.MistralInstruct:
+        chat_messages = [
+            {"role": "system", "content": PromptConstants.SYSTEM_MESSAGE_GENERIC},
+        ]
+        chat_messages += [
+            {
+                "role": "user",
+                "content": get_generic_question_template_answer(question, code, result, metadata),
+            },
+        ]
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            "mistralai/Mistral-7B-Instruct-v0.2", padding_side="left", use_fast=False
+        )
+        return tokenizer.apply_chat_template(
+            chat_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            truncation=False,
+            padding=False,
+        )
     elif LanguageModelStyle == LMStyle.Gemini:
         prompt = f"{PromptConstants.SYSTEM_MESSAGE_GENERIC}\n{get_generic_question_template_answer(question, code, result,metadata)}"
         return prompt

--- a/lcb_runner/prompts/test_output_prediction.py
+++ b/lcb_runner/prompts/test_output_prediction.py
@@ -273,6 +273,31 @@ def format_prompt_test_output(
             },
         ]
         return chat_messages
+    elif LanguageModelStyle == LMStyle.MistralInstruct:
+        chat_messages = [
+            {
+                "role": "system",
+                "content": PromptConstants.SYSTEM_MESSAGE_CHAT_GENERIC,
+            },
+            {
+                "role": "user",
+                "content": get_generic_question_template_test_completion(
+                    question, testcase_input
+                ),
+            },
+        ]
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            "mistralai/Mistral-7B-Instruct-v0.2", padding_side="left", use_fast=False
+        )
+        return tokenizer.apply_chat_template(
+            chat_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            truncation=False,
+            padding=False,
+        )
     elif (
         LanguageModelStyle == LMStyle.DracarysQwen
     ):


### PR DESCRIPTION
## Summary
- allow running `mistralai/Mistral-7B-Instruct-v0.2`
- add prompt formatting for `MistralInstruct` in generation, execution, self repair and test prediction
- fix link for Mistral 7B Instruct entry

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a8367e4c08327b4bfdfa2dd74b762